### PR TITLE
fix: use patch rather than git for patching the vendored modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ include(GNUInstallDirs)
 
 enable_language(C CXX)
 
+option(ANDROID_BUILD_TOOLS_DEV_MODE "Enable dev mode to ease upstreaming of patches to Google" OFF)
+
 # Use C11 with GNU extensions.
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_EXTENSIONS ON)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -22,11 +22,23 @@ if(ANDROID_BUILD_TOOLS_PATCH_VENDOR AND EXISTS "${ANDROID_PATCH_DIR}/")
         file(GLOB patches ${ANDROID_PATCH_DIR}/${v}/*.patch)
         if(patches)
             message(STATUS "Applying patches for: ${v}")
-            execute_process(COMMAND git -C
-                ${CMAKE_CURRENT_SOURCE_DIR}/${v} am ${patches}
-                RESULT_VARIABLE ret)
-            if(NOT "${ret}" STREQUAL "0")
-                message(FATAL_ERROR "Couldn't apply patches for ${v}")
+
+            if (ANDROID_BUILD_TOOLS_DEV_MODE)
+                foreach (patch ${patches})
+                    execute_process(COMMAND patch -d
+                        ${CMAKE_CURRENT_SOURCE_DIR}/${v} -p1 -i ${patch}
+                        RESULT_VARIABLE ret)
+                    if(NOT "${ret}" STREQUAL "0")
+                        message(FATAL_ERROR "Couldn't apply patch ${patch} for ${v}")
+                    endif()
+                endforeach(patch)
+            else()
+                execute_process(COMMAND git -C
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${v} am ${patches}
+                    RESULT_VARIABLE ret)
+                if(NOT "${ret}" STREQUAL "0")
+                    message(FATAL_ERROR "Couldn't apply patches for ${v}")
+                endif()
             endif()
         endif(patches)
     endforeach(v)


### PR DESCRIPTION
This way distro build systems don't need to setup git (`user.email` and `user.name`).